### PR TITLE
fix: manage report issue lifecycle based on violations

### DIFF
--- a/.github/actions/manage-report-issue/action.yml
+++ b/.github/actions/manage-report-issue/action.yml
@@ -1,0 +1,76 @@
+name: "Manage Report Issue"
+description: >
+  Manages the full lifecycle of a governance report issue:
+  creates, updates, reopens, or closes based on whether violations were found.
+inputs:
+  title:
+    description: "The issue title used to find and manage the report issue"
+    required: true
+  report-path:
+    description: "Path to the markdown report file"
+    required: true
+  has-violations:
+    description: "Whether the report found any violations ('true' or 'false')"
+    required: true
+  token:
+    description: "GitHub token for API access"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        TITLE: ${{ inputs.title }}
+        HAS_VIOLATIONS: ${{ inputs.has-violations }}
+        REPORT_PATH: ${{ inputs.report-path }}
+      run: |
+        set -euo pipefail
+
+        # Find existing issue by exact title (any state)
+        ISSUE_NUMBER=$(
+          gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state all \
+            --search "in:title \"${TITLE}\"" \
+            --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" \
+          | head -1
+        )
+
+        if [ "$HAS_VIOLATIONS" = "true" ]; then
+          if [ -n "$ISSUE_NUMBER" ]; then
+            echo "Updating existing issue #${ISSUE_NUMBER}"
+            gh issue edit "$ISSUE_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body-file "$REPORT_PATH"
+            gh issue reopen "$ISSUE_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" 2>/dev/null || true
+          else
+            echo "Creating new report issue"
+            gh issue create \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$TITLE" \
+              --body-file "$REPORT_PATH"
+          fi
+        else
+          if [ -n "$ISSUE_NUMBER" ]; then
+            ISSUE_STATE=$(
+              gh issue view "$ISSUE_NUMBER" \
+                --repo "$GITHUB_REPOSITORY" \
+                --json state \
+                --jq .state
+            )
+            if [ "$ISSUE_STATE" = "OPEN" ]; then
+              echo "Closing resolved issue #${ISSUE_NUMBER}"
+              gh issue close "$ISSUE_NUMBER" \
+                --repo "$GITHUB_REPOSITORY" \
+                --comment "✅ All violations have been resolved."
+            else
+              echo "No open issue to close"
+            fi
+          else
+            echo "No violations and no existing issue — nothing to do"
+          fi
+        fi

--- a/.github/workflows/report-repos-with-multi-admin-teams.yml
+++ b/.github/workflows/report-repos-with-multi-admin-teams.yml
@@ -53,9 +53,10 @@ jobs:
         run: |
           bun run report:repos-with-multi-admin-teams
 
-      - name: Upload report to issue
-        uses: step-security/create-issue-from-file@7444673975a4ae46c089644f50930db91fc53e4f # v6.0.0
+      - name: Manage report issue
+        uses: ./.github/actions/manage-report-issue
         with:
           title: "[report] Repos with Multiple Admin Teams"
-          content-filepath: ${{ steps.report.outputs.report-path }}
+          report-path: ${{ steps.report.outputs.report-path }}
+          has-violations: ${{ steps.report.outputs.has-violations }}
           token: ${{ steps.get-token.outputs.token }}

--- a/.github/workflows/report-repos-with-no-admin-team.yml
+++ b/.github/workflows/report-repos-with-no-admin-team.yml
@@ -53,9 +53,10 @@ jobs:
         run: |
           bun run report:repos-with-no-admin-team
 
-      - name: Upload report to issue
-        uses: step-security/create-issue-from-file@7444673975a4ae46c089644f50930db91fc53e4f # v6.0.0
+      - name: Manage report issue
+        uses: ./.github/actions/manage-report-issue
         with:
           title: "[report] Repos with No Admin Team"
-          content-filepath: ${{ steps.report.outputs.report-path }}
+          report-path: ${{ steps.report.outputs.report-path }}
+          has-violations: ${{ steps.report.outputs.has-violations }}
           token: ${{ steps.get-token.outputs.token }}

--- a/.github/workflows/report-repos-with-no-team.yml
+++ b/.github/workflows/report-repos-with-no-team.yml
@@ -53,9 +53,10 @@ jobs:
         run: |
           bun run report:repos-with-no-team
 
-      - name: Upload report to issue
-        uses: step-security/create-issue-from-file@7444673975a4ae46c089644f50930db91fc53e4f # v6.0.0
+      - name: Manage report issue
+        uses: ./.github/actions/manage-report-issue
         with:
           title: "[report] Repos with No Team Assigned"
-          content-filepath: ${{ steps.report.outputs.report-path }}
+          report-path: ${{ steps.report.outputs.report-path }}
+          has-violations: ${{ steps.report.outputs.has-violations }}
           token: ${{ steps.get-token.outputs.token }}


### PR DESCRIPTION
## Summary

Fixes the issue where all report workflows unconditionally create/update a GitHub issue — even when no violations are found — and create duplicate issues when violations recur after a previous issue was closed.

## Changes

- **New composite action** (`.github/actions/manage-report-issue/action.yml`) — uses `gh` CLI to manage the full issue lifecycle:
  - **Violations found →** create new issue, or update + reopen existing
  - **No violations →** close existing open issue with a resolution comment, or do nothing
- **Updated all 3 report workflows** to use the composite action instead of `step-security/create-issue-from-file`

### Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Violations, no existing issue | Creates issue ✅ | Creates issue ✅ |
| Violations, open issue exists | Updates body ✅ | Updates body ✅ |
| Violations, closed issue exists | Creates **duplicate** ❌ | Reopens + updates ✅ |
| No violations, no existing issue | Creates noisy issue ❌ | Does nothing ✅ |
| No violations, open issue exists | Updates with "all good" ❌ | Closes with comment ✅ |
| No violations, closed issue exists | Creates **duplicate** ❌ | Does nothing ✅ |

No TypeScript changes — the `has-violations` and `report-path` outputs already existed in `writeReportOutput`.