### PR TITLE
chore: pin actions to v2.1.0 SHA

### DIFF
--- a/.github/workflows/report-repos-with-multi-admin-teams.yml
+++ b/.github/workflows/report-repos-with-multi-admin-teams.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-multi-admin-teams
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@e3a0bd51f2159079c77872080d493bc5ab9dc8bc # feat: add upsert-issue
+        uses: devantler-tech/actions/upsert-issue@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
         with:
           title: "[report] Repos with Multiple Admin Teams"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-no-admin-team.yml
+++ b/.github/workflows/report-repos-with-no-admin-team.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-no-admin-team
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@e3a0bd51f2159079c77872080d493bc5ab9dc8bc # feat: add upsert-issue
+        uses: devantler-tech/actions/upsert-issue@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
         with:
           title: "[report] Repos with No Admin Team"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-no-team.yml
+++ b/.github/workflows/report-repos-with-no-team.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-no-team
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@e3a0bd51f2159079c77872080d493bc5ab9dc8bc # feat: add upsert-issue
+        uses: devantler-tech/actions/upsert-issue@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
         with:
           title: "[report] Repos with No Team Assigned"
           body-file: ${{ steps.report.outputs.report-path }}


### PR DESCRIPTION
Pin all `devantler-tech/actions` workflow callsites to the latest semver release SHA:
`4235593b654b467bb57c2d2f492b1461eab37cba` (`v2.1.0`).

Fixes N/A

## Type of change

EOF- [ ] - [ ] - [ ] - [ ] - [x] 