### PR TITLE
fix: bump upsert-issue action ref

### DIFF
--- a/.github/workflows/report-repos-with-multi-admin-teams.yml
+++ b/.github/workflows/report-repos-with-multi-admin-teams.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-multi-admin-teams
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
+        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
         with:
           title: "[report] Repos with Multiple Admin Teams"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-no-admin-team.yml
+++ b/.github/workflows/report-repos-with-no-admin-team.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-no-admin-team
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
+        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
         with:
           title: "[report] Repos with No Admin Team"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-no-team.yml
+++ b/.github/workflows/report-repos-with-no-team.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-no-team
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@4235593b654b467bb57c2d2f492b1461eab37cba # v2.1.0
+        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
         with:
           title: "[report] Repos with No Team Assigned"
           body-file: ${{ steps.report.outputs.report-path }}


### PR DESCRIPTION
Please include a summary of the changes. **What** has changed and **why**?.

Updates the direct `devantler-tech/actions/upsert-issue` pins in `maintenance` to the merged commit from https://github.com/devantler-tech/actions/pull/72. This keeps the scheduled report workflows on the same merged action revision that normalized the action input names.

These refs now point at the released `v2.1.1` commit from https://github.com/devantler-tech/actions/pull/72.

Fixes N/A

## Type of change

Select the appropriate options and delete the rest:

- [ ] 🧹 Refactor
- [x] 🪲 Bug fix
- [ ] 🚀 New feature
- [ ] ⛓️‍💥 Breaking change
- [ ] 📚 Documentation update
