### PR TITLE
fix: use v2.1.1 tag ref for upsert-issue

### DIFF
--- a/.github/workflows/report-repos-with-multi-admin-teams.yml
+++ b/.github/workflows/report-repos-with-multi-admin-teams.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-multi-admin-teams
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
+        uses: devantler-tech/actions/upsert-issue@v2.1.1
         with:
           title: "[report] Repos with Multiple Admin Teams"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-multi-admin-teams.yml
+++ b/.github/workflows/report-repos-with-multi-admin-teams.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-multi-admin-teams
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@v2.1.1
+        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
         with:
           title: "[report] Repos with Multiple Admin Teams"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-no-admin-team.yml
+++ b/.github/workflows/report-repos-with-no-admin-team.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-no-admin-team
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@v2.1.1
+        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
         with:
           title: "[report] Repos with No Admin Team"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-no-admin-team.yml
+++ b/.github/workflows/report-repos-with-no-admin-team.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-no-admin-team
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
+        uses: devantler-tech/actions/upsert-issue@v2.1.1
         with:
           title: "[report] Repos with No Admin Team"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-no-team.yml
+++ b/.github/workflows/report-repos-with-no-team.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-no-team
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@v2.1.1
+        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # v2.1.1
         with:
           title: "[report] Repos with No Team Assigned"
           body-file: ${{ steps.report.outputs.report-path }}

--- a/.github/workflows/report-repos-with-no-team.yml
+++ b/.github/workflows/report-repos-with-no-team.yml
@@ -54,7 +54,7 @@ jobs:
           bun run report:repos-with-no-team
 
       - name: Manage report issue
-        uses: devantler-tech/actions/upsert-issue@961f62f4a771b31e48acaae4a619cef6c7fe2195 # unreleased
+        uses: devantler-tech/actions/upsert-issue@v2.1.1
         with:
           title: "[report] Repos with No Team Assigned"
           body-file: ${{ steps.report.outputs.report-path }}


### PR DESCRIPTION
Please include a summary of the changes. **What** has changed and **why**?.

Updated the specified maintenance workflows to use `devantler-tech/actions/upsert-issue@v2.1.1` instead of the merged commit-SHA pin with a trailing comment. This applies the intended follow-up correction so the workflows reference the released tag.

Fixes N/A

## Type of change

Select the appropriate options and delete the rest:

EOF- [ ] - [ ] - [ ] - [x] - [ ] 