### PR TITLE
ci: add aggregated 'CI - Required Checks' job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,17 +221,20 @@ jobs:
           egress-policy: audit
 
       - name: Verify required checks passed
+        env:
+          CI_RESULT: ${{ needs.ci.result }}
+          AUTO_COMMIT_RESULT: ${{ needs.auto-commit.result }}
         run: |
-          echo "ci: ${{ needs.ci.result }}"
-          echo "auto-commit: ${{ needs.auto-commit.result }}"
+          echo "ci: $CI_RESULT"
+          echo "auto-commit: $AUTO_COMMIT_RESULT"
 
-          if [[ "${{ needs.ci.result }}" != "success" ]]; then
+          if [[ "$CI_RESULT" != "success" ]]; then
             echo "::error::CI checks failed or were cancelled."
             exit 1
           fi
 
-          if [[ "${{ needs.auto-commit.result }}" == "failure" ]]; then
-            echo "::error::Auto-commit failed."
+          if [[ "$AUTO_COMMIT_RESULT" != "success" && "$AUTO_COMMIT_RESULT" != "skipped" ]]; then
+            echo "::error::Auto-commit failed or was cancelled."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,3 +206,33 @@ jobs:
         with:
           commit_message: "chore: auto-fix lockfile and formatting"
           branch: ${{ github.head_ref }}
+
+  required-checks:
+    name: CI - Required Checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs: [ci, auto-commit]
+    permissions: {}
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0
+        with:
+          egress-policy: audit
+
+      - name: Verify required checks passed
+        run: |
+          echo "ci: ${{ needs.ci.result }}"
+          echo "auto-commit: ${{ needs.auto-commit.result }}"
+
+          if [[ "${{ needs.ci.result }}" != "success" ]]; then
+            echo "::error::CI checks failed or were cancelled."
+            exit 1
+          fi
+
+          if [[ "${{ needs.auto-commit.result }}" == "failure" ]]; then
+            echo "::error::Auto-commit failed."
+            exit 1
+          fi
+
+          echo "All required checks passed."


### PR DESCRIPTION
## Summary

Add a terminal aggregation job (`CI - Required Checks`) to the CI workflow that satisfies the org-wide ruleset requiring a single status check on PRs.

## Changes

- Added `required-checks` job to `.github/workflows/ci.yml`
- The job `needs: [ci, auto-commit]`, transitively covering all 4 existing jobs
- Uses `if: always()` so it runs even when `auto-commit` is skipped (pushes to main, fork PRs)
- Requires `ci` to succeed; tolerates `auto-commit` skip but fails on error

## Behavior matrix

| Event | `ci` | `auto-commit` | `CI - Required Checks` |
|---|---|---|---|
| PR (same repo) | ✅ must pass | ✅ must pass or skip | ✅ gates on both |
| PR (fork) | ✅ must pass | ⏭️ skipped (ok) | ✅ gates on `ci` |
| Push to main | ✅ must pass | ⏭️ skipped (ok) | ✅ gates on `ci` |