### PR TITLE
ci: exempt internal devantler-tech deps from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,6 +6,9 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+      # devantler-tech actions/workflows are our own code — bump now, no cooldown.
+      exclude:
+        - "devantler-tech/*"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
## What

Adds `exclude: ["devantler-tech/*"]` to the Dependabot `github-actions` cooldown so internal `devantler-tech/actions` + reusable-workflow bumps land immediately instead of waiting 7 days.

Per Dependabot's `WildcardMatcher`, `*` compiles to `.*` (anchored, matches across `/`), so it covers both `devantler-tech/actions` and `devantler-tech/reusable-workflows/.github/workflows/<file>.yaml`.

## Why

We trust our own code (CI is the gate), so internal bumps shouldn't sit in cooldown like third-party deps. Companion to devantler-tech/monorepo#1782 (portfolio-wide pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
